### PR TITLE
Fixes to address issue with package name.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
-Package: woslite_r_client
+Package: wosliterclient
 Title: R Package Client for Web of Science API Lite
 Version: 1.0.0
 Authors@R: person("OpenAPI Generator community", email = "team@openapitools.org", role = c("aut", "cre"))
 Description: A responsive API that supports rich searching across the Web of Science Core Collection to retrieve core article metadata.  This service provides a great way to reuse Web of Science data both internally and externally to enhance  institutional repositories and research networking systems with best-in-class data. This API supports searching across the Web of Science to retrieve item-level metadata with limited fields:  - UT (Unique Identifier) - Authors - Author keywords - Document type - Title - Issue - Pages - Publication date - Source title - Volume - DOI - ISBN - ISSN   The API supports JSON and XML responses, and this documentation supports trying both response types. 
-URL: https://github.com/GIT_USER_ID/GIT_REPO_ID
-BugReports: https://github.com/GIT_USER_ID/GIT_REPO_ID/issues
+URL: https://github.com/Clarivate-SAR/woslite_r_client
+BugReports: https://github.com/Clarivate-SAR/woslite_r_client/issues
 Depends: R (>= 3.3)
 Encoding: UTF-8
-License: Unlicense
+License: MIT + file LICENSE
 LazyData: true
 Suggests: testthat
 Imports: jsonlite, httr, R6, base64enc

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
-library(woslite_r_client)
+library(wosliterclient)
 
-test_check("woslite_r_client")
+test_check("wosliterclient")


### PR DESCRIPTION
- Relates to #2.

- Note "The mandatory ‘Package’ field gives the name of the package. This should contain only (ASCII) letters, numbers and dot, have at least two characters and start with a letter and not end in a dot" (see [here](https://cran.r-project.org/doc/manuals/r-release/R-exts.html)).
- Also referenced LICENSE file.
- Also fixed URL and BugReports links.